### PR TITLE
Restructure docs: split CLI reference into child pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,10 @@ url: https://radaiko.github.io/Graft
 
 search_enabled: true
 
+heading_anchors: true
+back_to_top: true
+back_to_top_text: "Back to top"
+
 exclude:
   - spec.md
   - spec/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,4 +14,4 @@ Release notes for each Graft product. Download binaries from the [GitHub Release
 | CLI | 0.2.2 | [View](changelog/cli) |
 | VS Code Extension | 0.1.0 | [View](changelog/vscode) |
 | Visual Studio | 0.1.0 | [View](changelog/vs) |
-| JetBrains Plugin | -- | [View](changelog/jetbrains) |
+| JetBrains Plugin | Planned | [View](changelog/jetbrains) |

--- a/docs/changelog/jetbrains.md
+++ b/docs/changelog/jetbrains.md
@@ -9,4 +9,8 @@ nav_order: 4
 
 ---
 
-No releases yet. Plugin is planned.
+**Status: Planned**
+
+The JetBrains plugin for IntelliJ IDEA, Rider, WebStorm, and other JetBrains IDEs is planned. No release date has been announced.
+
+Follow the [GitHub repository](https://github.com/radaiko/Graft) for updates.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,370 +2,45 @@
 layout: default
 title: CLI Reference
 nav_order: 3
+has_children: true
 ---
 
 # CLI Reference
 
-Complete command reference for the Graft CLI.
+Complete command reference for the Graft CLI. Commands are grouped by function — click through to each page for detailed usage, examples, and tips.
 
 ---
 
-## Stack Commands
+## Command Groups
 
-All stack commands operate on the **active stack**. Use `graft stack switch` to change which stack is active.
-
-### `graft stack init <name> [-b/--base <branch>]`
-
-Create a new stack. Uses the current branch as trunk, or the branch specified with `-b`. The new stack becomes the active stack.
-
-```bash
-$ graft stack init my-feature
-Created stack 'my-feature' with trunk 'main'.
-Active stack: my-feature
-
-$ graft stack init hotfix -b release/2.0
-Created stack 'hotfix' with trunk 'release/2.0'.
-Active stack: hotfix
-```
-
-### `graft stack list` (alias: `ls`)
-
-List all stacks. The active stack is marked with `*`.
-
-```bash
-$ graft stack list
-* my-feature  (trunk: main, 3 branches)
-  hotfix      (trunk: release/2.0, 1 branch)
-```
-
-### `graft stack switch <name>` (alias: `sw`)
-
-Switch the active stack. Fails if the named stack does not exist.
-
-```bash
-$ graft stack switch hotfix
-Active stack: hotfix
-```
-
-### `graft stack push <branch> [-c/--create]`
-
-Add a branch to the top of the active stack. With `-c`, creates the branch first. The branch is checked out.
-
-```bash
-# Add an existing branch
-$ graft stack push feature/auth
-Pushed 'feature/auth' to stack 'my-feature'.
-
-# Create a new branch and add it
-$ graft stack push -c feature/api
-Created branch 'feature/api'.
-Pushed 'feature/api' to stack 'my-feature'.
-```
-
-### `graft stack pop`
-
-Remove the topmost branch from the active stack. The git branch is kept.
-
-```bash
-$ graft stack pop
-Popped 'feature/api' from stack 'my-feature'.
-```
-
-### `graft stack drop <branch>`
-
-Remove the named branch from the stack regardless of position. The git branch is kept. Use this after a branch's PR is squash-merged.
-
-```bash
-$ graft stack drop feature/auth
-Dropped 'feature/auth' from stack 'my-feature'.
-```
-
-### `graft stack shift <branch>`
-
-Insert an existing branch at the bottom of the stack (directly above the trunk). Useful when you need to add a base branch that other branches depend on.
-
-```bash
-$ graft stack shift feature/config
-Shifted 'feature/config' to bottom of stack 'my-feature'.
-```
-
-### `graft stack commit --message "<message>" [-b <branch>] [--amend]` (alias: `ci`)
-
-Commit staged changes to the active stack. Defaults to the topmost branch. Use `-b` to target a specific branch. Use `--amend` to amend the latest commit. Short form: `-m`.
-
-```bash
-# Commit to the topmost branch
-$ git add src/api.cs
-$ graft stack commit -m "add API endpoint"
-
-# Commit to a specific branch (stash/checkout/commit/return)
-$ git add src/auth.cs
-$ graft stack commit -m "fix auth bug" -b feature/auth
-
-# Amend the latest commit on a branch
-$ git add src/auth.cs
-$ graft stack commit -m "fix auth bug" --amend -b feature/auth
-```
-
-### `graft stack sync [<branch>]`
-
-Sync branches: fetch, merge each branch's parent into it (bottom-to-top), then push all updated branches. Optionally sync only the named branch.
-
-```bash
-# Sync entire stack
-$ graft stack sync
-Fetching...
-Merging main → feature/auth... up-to-date.
-Merging feature/auth → feature/api... done.
-Pushing feature/api... done.
-
-# Sync a single branch
-$ graft stack sync feature/auth
-```
-
-### `graft stack log`
-
-Show a visual graph of the active stack with branch relationships.
-
-```bash
-$ graft stack log
-Stack: my-feature (trunk: main)
-  main
-   └── feature/auth    (2 commits)
-        └── feature/api (1 commit)
-```
-
-### `graft stack remove <name> [-f/--force]` (alias: `rm`)
-
-Remove a stack. Prompts for confirmation unless `--force` is used. Git branches are kept. If the removed stack was active, the active stack is cleared.
-
-```bash
-$ graft stack remove my-feature
-Removed stack 'my-feature'.
-```
+| Group | Commands | Description |
+|-------|----------|-------------|
+| [Stack](cli/stack) | `init`, `list`, `switch`, `push`, `pop`, `drop`, `shift`, `commit`, `sync`, `log`, `remove` | Create, manage, and sync stacked branches |
+| [Worktree](cli/worktree) | `wt`, `wt remove`, `wt list` | Manage parallel checkouts with fixed naming |
+| [Scan & Discovery](cli/scan) | `scan add`, `scan remove`, `scan list`, `scan auto-fetch` | Register directories, discover repos, background fetch |
+| [Navigation](cli/navigation) | `cd` | Jump to repos and worktrees by name |
+| [Status](cli/status) | `status` | Cross-repo overview of all discovered repos |
+| [Nuke](cli/nuke) | `nuke`, `nuke wt`, `nuke stack`, `nuke branches` | Bulk cleanup operations |
+| [Conflict Resolution](cli/conflict) | `--continue`, `--abort` | Handle merge conflicts during sync |
+| [Setup](cli/setup) | `install`, `uninstall`, `update`, `version`, `ui` | Installation, aliases, and updates |
 
 ---
 
-## Worktree Commands
+## Naming Conventions
 
-Worktree paths follow the convention `../<reponame>.wt.<safebranch>/` where slashes in branch names are replaced with hyphens.
+Commands use **full names** as primary, with **short aliases** registered as hidden alternatives:
 
-Example: branch `feature/api` in repo `Graft` → `../Graft.wt.feature-api/`
+| Action | Full (primary) | Short (alias) |
+|--------|---------------|---------------|
+| Remove | `remove` | `rm` |
+| List | `list` | `ls` |
+| Switch | `switch` | `sw` |
+| Commit | `commit` | `ci` |
+| Status | `status` | `st` |
 
-### `graft wt <branch> [-c/--create]`
+Options always have a long form primary with a short alias: `--force`/`-f`, `--create`/`-c`, `--message`/`-m`, `--base`/`-b`.
 
-Create a worktree for an existing branch. With `-c`, creates the branch first.
-
-```bash
-# Worktree for an existing branch
-$ graft wt feature/auth
-Created worktree at ../Graft.wt.feature-auth/
-
-# Create new branch + worktree
-$ graft wt feature/new-thing -c
-Created branch 'feature/new-thing'.
-Created worktree at ../Graft.wt.feature-new-thing/
-```
-
-### `graft wt remove <branch> [-f/--force]` (alias: `rm`)
-
-Remove the worktree for the named branch. Prompts for confirmation. Fails if uncommitted changes exist unless `-f` is used to override dirty checks. Also removes the worktree from the repo cache.
-
-```bash
-$ graft wt remove feature/auth
-Removed worktree at ../Graft.wt.feature-auth/
-
-# Force-remove even with uncommitted changes
-$ graft wt remove feature/auth -f
-```
-
-### `graft wt list` (alias: `ls`)
-
-List all worktrees of this repository.
-
-```bash
-$ graft wt list
-/Users/dev/Graft                          main
-/Users/dev/Graft.wt.feature-auth          feature/auth
-/Users/dev/Graft.wt.feature-api           feature/api
-```
-
----
-
-## Scan Commands
-
-Manage directories that Graft scans for git repositories. Discovered repos power `graft cd` and `graft status`.
-
-### `graft scan add <directory>`
-
-Register a directory to scan for git repositories.
-
-```bash
-$ graft scan add ~/dev/projects
-Added scan path: /Users/dev/projects
-```
-
-### `graft scan remove <directory>` (alias: `rm`)
-
-Remove a directory from the scan list.
-
-```bash
-$ graft scan remove ~/dev/projects
-Removed scan path: /Users/dev/projects
-```
-
-### `graft scan list` (alias: `ls`)
-
-List all registered scan paths.
-
-```bash
-$ graft scan list
-/Users/dev/projects
-/Users/dev/work
-```
-
----
-
-## Navigation
-
-### `graft cd <name>`
-
-Navigate to a discovered repo or worktree. Matches repo names first, then branch names for worktrees.
-
-```bash
-# Jump to a repo by name
-$ graft cd my-app
-
-# Jump to a worktree by branch name
-$ graft cd feature/auth
-# → ../Graft.wt.feature-auth/
-```
-
-If multiple matches exist, all are shown and you pick one. Works via a shell function since a child process can't change the parent's working directory.
-
----
-
-## Status
-
-### `graft status` (alias: `st`)
-
-Show a compact overview of all discovered repos.
-
-```bash
-$ graft status
-Graft  ~/dev/projects/Graft
-  branch   main
-  status   ✓ clean
-  stack    auth-refactor (3 branches)
-  worktrees  2 active
-
-my-app  ~/dev/projects/my-app
-  branch   feature/api
-  status   ↑2 ↓1  3 changed
-```
-
-### `graft status <reponame>` (alias: `st`)
-
-Show detailed status for a specific repo including stack graph and worktree list.
-
----
-
-## Nuke Commands
-
-Bulk cleanup operations. All require confirmation. Use `-f`/`--force` to override dirty checks on worktree removal.
-
-### `graft nuke [-f/--force]`
-
-Remove all worktrees, stacks, and gone branches.
-
-### `graft nuke wt [-f/--force]`
-
-Remove all worktrees.
-
-### `graft nuke stack`
-
-Remove all stacks. Git branches are kept.
-
-### `graft nuke branches`
-
-Remove local branches whose remote tracking branch is gone. Uses `git branch -d` (safe delete — won't delete unmerged branches).
-
-```bash
-$ graft nuke branches
-Deleted branch 'feature/old-thing' (was abc1234).
-Deleted branch 'bugfix/resolved' (was def5678).
-Removed 2 branches.
-```
-
----
-
-## Conflict Resolution
-
-### `graft --continue`
-
-Continue after resolving conflicts during a sync operation. Finishes the current merge and proceeds to remaining branches.
-
-```bash
-# After resolving conflicts:
-$ git add src/conflicted-file.cs
-$ graft --continue
-Merge complete.
-Merging feature/auth → feature/api... done.
-Pushing feature/auth... done.
-Pushing feature/api... done.
-```
-
-### `graft --abort`
-
-Abort an in-progress sync operation. Aborts the merge and restores the original branch.
-
-```bash
-$ graft --abort
-Aborted. Restored to 'feature/api'.
-```
-
----
-
-## Setup Commands
-
-### `graft install`
-
-Create the `gt` shortcut next to the `graft` binary and add `git gt` alias to your global git config.
-
-```bash
-$ graft install
-Created symlink: gt → /usr/local/bin/graft
-Added git alias: git gt → graft
-```
-
-### `graft uninstall`
-
-Remove the `gt` shortcut and `git gt` alias.
-
-### `graft update`
-
-Check for updates and apply if available.
-
-```bash
-$ graft update
-Checking for updates...
-New version available: v0.3.0 (current: v0.2.0)
-Downloading... done.
-Update will be applied on next run.
-```
-
-### `graft version`
-
-Print the current version.
-
-```bash
-$ graft version
-graft 0.2.0
-```
-
-### `graft ui`
-
-Start the web-based UI. See [Web UI](web-ui).
+The binary name is `graft`. After running `graft install`, you can also use `gt` (symlink) or `git gt` (git alias). All three forms are interchangeable.
 
 ---
 

--- a/docs/cli/conflict.md
+++ b/docs/cli/conflict.md
@@ -1,0 +1,103 @@
+---
+layout: default
+title: Conflict Resolution
+parent: CLI Reference
+nav_order: 7
+---
+
+# Conflict Resolution
+
+Handle merge conflicts that occur during `graft stack sync`.
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `graft --continue` | Continue after resolving conflicts |
+| `graft --abort` | Abort the in-progress sync |
+
+---
+
+## When Conflicts Happen
+
+Only `sync` can produce merge conflicts. All other Graft commands modify metadata or commit changes — they never merge.
+
+When `sync` merges a parent branch into a child branch and the merge can't be completed automatically, Graft pauses and tells you exactly what to do:
+
+```
+Error: Merge conflict in 'auth/session'
+
+Conflicting files:
+  - src/Auth/SessionManager.cs
+  - src/Auth/TokenValidator.cs
+
+To resolve:
+  1. Fix conflicts in the files above
+  2. Stage resolved files: git add <file>
+  3. Continue: graft --continue
+
+To abort: graft --abort
+```
+
+Graft saves its state to `.git/graft/operation.toml` so it can resume where it left off.
+
+---
+
+## `graft --continue`
+
+Continue after resolving conflicts during a sync operation. Finishes the current merge and proceeds to remaining branches in the stack.
+
+```bash
+# After resolving conflicts:
+$ git add src/Auth/SessionManager.cs src/Auth/TokenValidator.cs
+$ graft --continue
+Merge complete.
+Merging auth/session → auth/api... done.
+Pushing auth/session... done.
+Pushing auth/api... done.
+```
+
+If another conflict occurs further up the stack, the process repeats — resolve, stage, `--continue`.
+
+---
+
+## `graft --abort`
+
+Abort an in-progress sync operation. Aborts the merge and restores your original branch.
+
+```bash
+$ graft --abort
+Aborted. Restored to 'feature/api'.
+```
+
+---
+
+## Conflict Resolution Workflow
+
+Here's the full workflow when a sync hits a conflict:
+
+1. **`graft stack sync`** — starts merging bottom-to-top
+2. **Conflict detected** — sync pauses, shows conflicting files
+3. **Fix conflicts** — open the files in your editor, resolve the merge markers
+4. **Stage resolved files** — `git add <file>` for each resolved file
+5. **Continue** — `graft --continue` finishes the merge and moves to the next branch
+6. **Repeat** — if another conflict occurs, go back to step 3
+
+At any point, `graft --abort` cancels the entire operation and restores your original state.
+
+---
+
+## Tips
+
+- **Check operation state**: If you're unsure whether a sync is in progress, look for `.git/graft/operation.toml`. If it exists, there's an unfinished operation.
+- **Web UI support**: The [Web UI](../web-ui) shows a conflict banner with Continue and Abort buttons when a sync is paused.
+- **Standard git tools work**: During a conflict, you're in a normal git merge state. All your usual tools (VS Code merge editor, IntelliJ merge tool, etc.) work as expected.
+
+---
+
+## See Also
+
+- [Stack Commands](stack) — `graft stack sync` triggers the merge cascade
+- [Workflow Guide](../workflow#conflict-handling) — Conflicts in the context of a full workflow

--- a/docs/cli/navigation.md
+++ b/docs/cli/navigation.md
@@ -1,0 +1,54 @@
+---
+layout: default
+title: Navigation
+parent: CLI Reference
+nav_order: 4
+---
+
+# Navigation
+
+Jump to any discovered repo or worktree with a single command.
+
+---
+
+## `graft cd <name>`
+
+Navigate to a discovered repo or worktree. Matches repo names first, then branch names for worktrees.
+
+```bash
+# Jump to a repo by name
+$ graft cd my-app
+
+# Jump to a worktree by branch name
+$ graft cd feature/auth
+# → ../Graft.wt.feature-auth/
+```
+
+### Multiple Matches
+
+If multiple repos or worktrees match the name, all matches are shown and you pick one interactively.
+
+### How It Works
+
+A child process can't change the parent shell's working directory. Graft handles this with a shell function that wraps the binary:
+
+1. `graft cd <name>` prints the target directory path to stdout
+2. The shell function captures this and runs `cd` in the parent shell
+
+The shell function is set up automatically by `graft install`. If you're using `graft` directly (without the shell function), the path is printed but the directory change won't happen — use `cd $(graft cd <name>)` as a workaround.
+
+---
+
+## Tips
+
+- **Register scan paths first**: `graft cd` only finds repos that are in the [scan cache](scan). Run `graft scan add <directory>` to register your project directories.
+- **Worktrees included automatically**: Worktrees created with `graft wt` are added to the cache, so `graft cd <branch>` works immediately.
+- **Case-insensitive matching**: Repo name matching is case-insensitive.
+
+---
+
+## See Also
+
+- [Scan & Discovery](scan) — Register directories to discover repos
+- [Status](status) — See all discovered repos at a glance
+- [Worktree Commands](worktree) — Create worktrees to navigate to

--- a/docs/cli/nuke.md
+++ b/docs/cli/nuke.md
@@ -1,0 +1,70 @@
+---
+layout: default
+title: Nuke Commands
+parent: CLI Reference
+nav_order: 6
+---
+
+# Nuke Commands
+
+Bulk cleanup operations for worktrees, stacks, and stale branches.
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `graft nuke [-f]` | Remove all worktrees, stacks, and gone branches |
+| `graft nuke wt [-f]` | Remove all worktrees |
+| `graft nuke stack` | Remove all stacks |
+| `graft nuke branches` | Remove branches whose upstream is gone |
+
+---
+
+## `graft nuke [-f/--force]`
+
+Remove all worktrees, stacks, and gone branches. Always prompts for confirmation. Use `-f` to override dirty checks on worktree removal (confirmation is still required).
+
+---
+
+## `graft nuke wt [-f/--force]`
+
+Remove all worktrees. Always prompts for confirmation. Fails if any worktree has uncommitted changes unless `-f` is used.
+
+---
+
+## `graft nuke stack`
+
+Remove all stacks. Git branches are kept — only the stack metadata in `.git/graft/stacks/` is removed.
+
+---
+
+## `graft nuke branches`
+
+Remove local branches whose remote tracking branch is gone. Uses `git branch -d` (safe delete — won't delete unmerged branches).
+
+```bash
+$ graft nuke branches
+Deleted branch 'feature/old-thing' (was abc1234).
+Deleted branch 'bugfix/resolved' (was def5678).
+Removed 2 branches.
+```
+
+This is useful after squash-merging PRs on GitHub/GitLab, which deletes the remote branch but leaves the local one behind.
+
+---
+
+## Safety
+
+- **All nuke commands prompt for confirmation.** The `--force` flag only overrides dirty checks (uncommitted changes in worktrees), not the confirmation prompt.
+- **Stacks are metadata only.** `graft nuke stack` removes stack definitions but never deletes git branches.
+- **Branch deletion is safe.** `graft nuke branches` uses `git branch -d`, which refuses to delete branches with unmerged commits.
+- **Reversibility**: Worktree removal is reversible (re-create with `graft wt`). Stack removal is reversible (re-create with `graft stack init` + `push`). Branch deletion via `-d` is safe — unmerged branches are protected.
+
+---
+
+## See Also
+
+- [Stack Commands](stack) — Manage individual stacks
+- [Worktree Commands](worktree) — Manage individual worktrees

--- a/docs/cli/scan.md
+++ b/docs/cli/scan.md
@@ -1,0 +1,115 @@
+---
+layout: default
+title: Scan & Discovery
+parent: CLI Reference
+nav_order: 3
+---
+
+# Scan & Discovery
+
+Manage directories that Graft scans for git repositories. Discovered repos power [`graft cd`](navigation) and [`graft status`](status).
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `graft scan add <directory>` | Register a directory for scanning |
+| `graft scan remove <directory>` | Unregister a directory |
+| `graft scan list` | List registered scan paths |
+| `graft scan auto-fetch enable [<name>]` | Enable background fetch for a repo |
+| `graft scan auto-fetch disable [<name>]` | Disable background fetch for a repo |
+| `graft scan auto-fetch list` | List repos with auto-fetch status |
+
+---
+
+## Scan Path Commands
+
+### `graft scan add <directory>`
+
+Register a directory to scan for git repositories.
+
+```bash
+$ graft scan add ~/dev/projects
+Added scan path: /Users/dev/projects
+```
+
+On every `graft` invocation, a background thread scans all registered paths for git repositories. The scan is non-blocking — the main command runs immediately. Results are cached in `~/.config/graft/repo-cache.toml`.
+
+### `graft scan remove <directory>` (alias: `rm`)
+
+Remove a directory from the scan list.
+
+```bash
+$ graft scan remove ~/dev/projects
+Removed scan path: /Users/dev/projects
+```
+
+### `graft scan list` (alias: `ls`)
+
+List all registered scan paths.
+
+```bash
+$ graft scan list
+/Users/dev/projects
+/Users/dev/work
+```
+
+---
+
+## Auto-Fetch Commands
+
+Repos can opt into automatic background fetching. When enabled, `git fetch --all --quiet` runs in a fire-and-forget background thread on every `graft` invocation, rate-limited to once every 15 minutes per repo.
+
+### `graft scan auto-fetch enable [<name>]`
+
+Enable auto-fetch for a repository. If `<name>` is provided, looks up the repo by name in the cache (case-insensitive). If omitted, uses the current working directory.
+
+```bash
+# Enable for the current repo
+$ graft scan auto-fetch enable
+Auto-fetch enabled for 'Graft'.
+
+# Enable for a named repo
+$ graft scan auto-fetch enable my-app
+Auto-fetch enabled for 'my-app'.
+```
+
+### `graft scan auto-fetch disable [<name>]`
+
+Disable auto-fetch for a repository. Same name/path resolution as `enable`. Also clears the `last_fetched` timestamp.
+
+```bash
+$ graft scan auto-fetch disable my-app
+Auto-fetch disabled for 'my-app'.
+```
+
+### `graft scan auto-fetch list` (alias: `ls`)
+
+List all cached repos with their auto-fetch status and last fetch time.
+
+```bash
+$ graft scan auto-fetch list
+Graft        on   last fetched 2 min ago
+my-app       off
+other-repo   on   last fetched 14 min ago
+```
+
+---
+
+## How Scanning Works
+
+- **Background thread**: Scanning runs in a non-blocking background thread on every invocation. Your command executes immediately.
+- **Stale removal**: If a cached repo no longer exists on disk, it's automatically pruned.
+- **Worktree integration**: `graft wt` automatically adds new worktrees to the repo cache. `graft wt remove` automatically removes them.
+- **Rate limiting (auto-fetch)**: Each repo tracks its own `last_fetched` UTC timestamp. A fetch is skipped if the repo was fetched within the last 15 minutes.
+- **Error handling (auto-fetch)**: Fetch failures (network errors, unreachable remotes) are silently skipped per repo. One repo failing does not prevent others from being fetched.
+
+---
+
+## See Also
+
+- [Navigation](navigation) — Use discovered repos with `graft cd`
+- [Status](status) — Cross-repo overview of discovered repos
+- [Worktree Commands](worktree) — Worktrees are auto-registered in the cache

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -1,0 +1,108 @@
+---
+layout: default
+title: Setup Commands
+parent: CLI Reference
+nav_order: 8
+---
+
+# Setup Commands
+
+Installation, aliases, updates, and the web UI.
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `graft install` | Create `gt` shortcut and `git gt` alias |
+| `graft uninstall` | Remove shortcuts and aliases |
+| `graft update` | Check for and apply updates |
+| `graft version` | Print current version |
+| `graft ui` | Start the web UI |
+
+---
+
+## `graft install`
+
+Create the `gt` shortcut next to the `graft` binary and add `git gt` alias to your global git config.
+
+```bash
+$ graft install
+Created symlink: gt → /usr/local/bin/graft
+Added git alias: git gt → graft
+```
+
+After installation, you can use any of these interchangeably:
+
+| Form | Example |
+|------|---------|
+| `graft` | `graft stack sync` |
+| `gt` | `gt stack sync` |
+| `git gt` | `git gt stack sync` |
+
+On macOS/Linux, `gt` is a symlink. On Windows, it's a copy of the binary.
+
+The `git gt` alias is written to `~/.gitconfig` as `gt = !graft`.
+
+---
+
+## `graft uninstall`
+
+Remove the `gt` shortcut and `git gt` alias.
+
+---
+
+## `graft update`
+
+Check for updates and apply if available.
+
+```bash
+$ graft update
+Checking for updates...
+New version available: v0.3.0 (current: v0.2.0)
+Downloading... done.
+Update will be applied on next run.
+```
+
+### Auto-Update
+
+Graft also checks for updates automatically in the background (at most once per hour). When a new version is found:
+
+1. The binary is downloaded to `~/.config/graft/staging/`
+2. A SHA-256 checksum is verified
+3. On your next invocation, the binary is replaced atomically and re-executed
+4. If the update fails, the previous binary is restored automatically
+
+No telemetry or usage data is collected. The only network request is a GitHub API call to check for new releases.
+
+---
+
+## `graft version`
+
+Print the current version.
+
+```bash
+$ graft version
+graft 0.2.0
+```
+
+---
+
+## `graft ui`
+
+Start the web-based UI. Opens your default browser automatically.
+
+```bash
+$ graft ui
+Server started at http://localhost:5123
+```
+
+See [Web UI](../web-ui) for details on the browser interface.
+
+---
+
+## See Also
+
+- [Web UI](../web-ui) — Browser-based interface for stacks and worktrees
+- [FAQ](../faq) — Auto-update details

--- a/docs/cli/stack.md
+++ b/docs/cli/stack.md
@@ -1,0 +1,208 @@
+---
+layout: default
+title: Stack Commands
+parent: CLI Reference
+nav_order: 1
+---
+
+# Stack Commands
+
+Create, manage, and sync stacked branches. All stack commands operate on the **active stack** — use `graft stack switch` to change which stack is active.
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `graft stack init <name> [-b <branch>]` | Create a new stack |
+| `graft stack list` | List all stacks |
+| `graft stack switch <name>` | Switch active stack |
+| `graft stack push <branch> [-c]` | Add branch to top of stack |
+| `graft stack pop` | Remove topmost branch |
+| `graft stack drop <branch>` | Remove named branch |
+| `graft stack shift <branch>` | Insert branch at bottom |
+| `graft stack commit -m <msg> [-b <branch>]` | Commit to a stack branch |
+| `graft stack sync [<branch>]` | Merge + push stack branches |
+| `graft stack log` | Show stack graph |
+| `graft stack remove <name> [-f]` | Delete a stack |
+
+---
+
+## `graft stack init <name> [-b/--base <branch>]`
+
+Create a new stack. Uses the current branch as trunk, or the branch specified with `-b`. The new stack becomes the active stack.
+
+```bash
+$ graft stack init my-feature
+Created stack 'my-feature' with trunk 'main'.
+Active stack: my-feature
+
+$ graft stack init hotfix -b release/2.0
+Created stack 'hotfix' with trunk 'release/2.0'.
+Active stack: hotfix
+```
+
+---
+
+## `graft stack list` (alias: `ls`)
+
+List all stacks. The active stack is marked with `*`.
+
+```bash
+$ graft stack list
+* my-feature  (trunk: main, 3 branches)
+  hotfix      (trunk: release/2.0, 1 branch)
+```
+
+---
+
+## `graft stack switch <name>` (alias: `sw`)
+
+Switch the active stack. Fails if the named stack does not exist.
+
+```bash
+$ graft stack switch hotfix
+Active stack: hotfix
+```
+
+---
+
+## `graft stack push <branch> [-c/--create]`
+
+Add a branch to the top of the active stack. With `-c`, creates the branch first. The branch is checked out.
+
+```bash
+# Add an existing branch
+$ graft stack push feature/auth
+Pushed 'feature/auth' to stack 'my-feature'.
+
+# Create a new branch and add it
+$ graft stack push -c feature/api
+Created branch 'feature/api'.
+Pushed 'feature/api' to stack 'my-feature'.
+```
+
+---
+
+## `graft stack pop`
+
+Remove the topmost branch from the active stack. The git branch is kept.
+
+```bash
+$ graft stack pop
+Popped 'feature/api' from stack 'my-feature'.
+```
+
+---
+
+## `graft stack drop <branch>`
+
+Remove the named branch from the stack regardless of position. The git branch is kept. Use this after a branch's PR is squash-merged.
+
+```bash
+$ graft stack drop feature/auth
+Dropped 'feature/auth' from stack 'my-feature'.
+```
+
+---
+
+## `graft stack shift <branch>`
+
+Insert an existing branch at the bottom of the stack (directly above the trunk). Useful when you need to add a base branch that other branches depend on.
+
+```bash
+$ graft stack shift feature/config
+Shifted 'feature/config' to bottom of stack 'my-feature'.
+```
+
+---
+
+## `graft stack commit --message "<message>" [-b <branch>] [--amend]` (alias: `ci`)
+
+Commit staged changes to the active stack. Defaults to the topmost branch. Use `-b` to target a specific branch. Use `--amend` to amend the latest commit. Short form: `-m`.
+
+```bash
+# Commit to the topmost branch
+$ git add src/api.cs
+$ graft stack commit -m "add API endpoint"
+
+# Commit to a specific branch (stash/checkout/commit/return)
+$ git add src/auth.cs
+$ graft stack commit -m "fix auth bug" -b feature/auth
+
+# Amend the latest commit on a branch
+$ git add src/auth.cs
+$ graft stack commit -m "fix auth bug" --amend -b feature/auth
+```
+
+When committing to a branch other than the current one, Graft:
+1. Stashes your current work
+2. Checks out the target branch
+3. Applies staged changes and commits
+4. Returns to your original branch
+5. Restores your stash
+
+{: .note }
+> Branches above the target become stale after a cross-branch commit. Run `graft stack sync` to propagate changes upward.
+
+---
+
+## `graft stack sync [<branch>]`
+
+Sync branches: fetch, merge each branch's parent into it (bottom-to-top), then push all updated branches. Optionally sync only the named branch.
+
+```bash
+# Sync entire stack
+$ graft stack sync
+Fetching...
+Merging main → feature/auth... up-to-date.
+Merging feature/auth → feature/api... done.
+Pushing feature/api... done.
+
+# Sync a single branch
+$ graft stack sync feature/auth
+```
+
+If a merge conflict occurs, sync pauses. See [Conflict Resolution](conflict) for how to continue or abort.
+
+---
+
+## `graft stack log`
+
+Show a visual graph of the active stack with branch relationships.
+
+```bash
+$ graft stack log
+Stack: my-feature (trunk: main)
+  main
+   └── feature/auth    (2 commits)
+        └── feature/api (1 commit)
+```
+
+---
+
+## `graft stack remove <name> [-f/--force]` (alias: `rm`)
+
+Remove a stack. Prompts for confirmation unless `--force` is used. Git branches are kept. If the removed stack was active, the active stack is cleared.
+
+```bash
+$ graft stack remove my-feature
+Removed stack 'my-feature'.
+```
+
+---
+
+## Tips
+
+- **Drop after squash-merge**: When a PR is squash-merged, `drop` the branch and `sync` to propagate changes upward. See the [Workflow Guide](../workflow#6-when-featurea-gets-squash-merged) for a walkthrough.
+- **Active stack auto-selection**: If exactly one stack exists, it's used automatically — no need to `switch`.
+- **Multiple stacks**: You can have stacks on different trunk branches (e.g. one on `main`, another on `release/2.0`). Branches can only belong to one stack at a time.
+
+---
+
+## See Also
+
+- [Workflow Guide](../workflow) — Full stacked branches walkthrough
+- [Conflict Resolution](conflict) — Handle merge conflicts during sync
+- [Nuke Commands](nuke) — Bulk remove all stacks

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: Status
+parent: CLI Reference
+nav_order: 5
+---
+
+# Status
+
+Cross-repo overview of all discovered repositories.
+
+---
+
+## `graft status` (alias: `st`)
+
+Show a compact overview of all discovered repos.
+
+```bash
+$ graft status
+Graft  ~/dev/projects/Graft
+  branch   main
+  status   ✓ clean
+  stack    auth-refactor (3 branches)
+  worktrees  2 active
+
+my-app  ~/dev/projects/my-app
+  branch   feature/api
+  status   ↑2 ↓1  3 changed
+```
+
+### Output Fields
+
+| Field | Description |
+|-------|-------------|
+| **branch** | Currently checked-out branch |
+| **status** | Clean/dirty indicator, ahead/behind remote counts, changed file count |
+| **stack** | Active stack name and branch count (if any) |
+| **worktrees** | Number of active worktrees (if any) |
+
+---
+
+## `graft status <reponame>` (alias: `st`)
+
+Show detailed status for a specific repo, including the full stack graph and worktree list.
+
+```bash
+$ graft status Graft
+Graft  ~/dev/projects/Graft
+  branch   main
+  status   ✓ clean
+
+  Stack: auth-refactor (trunk: main)
+    main
+     └── auth/types       ✓ up-to-date
+          └── auth/session ↑1
+               └── auth/api ⚠ needs sync
+
+  Worktrees:
+    ../Graft.wt.auth-types     auth/types
+    ../Graft.wt.auth-session   auth/session
+```
+
+---
+
+## Tips
+
+- **Requires scan paths**: Status only shows repos in the [scan cache](scan). Run `graft scan add <directory>` first.
+- **Background scanning**: The repo list updates automatically in the background on every `graft` invocation.
+- **Quick navigation**: Spot a repo that needs attention? Jump to it with `graft cd <name>`. See [Navigation](navigation).
+
+---
+
+## See Also
+
+- [Scan & Discovery](scan) — Register directories to discover repos
+- [Navigation](navigation) — Jump to repos from the status overview
+- [Stack Commands](stack) — Manage stacks shown in status output

--- a/docs/cli/worktree.md
+++ b/docs/cli/worktree.md
@@ -1,0 +1,103 @@
+---
+layout: default
+title: Worktree Commands
+parent: CLI Reference
+nav_order: 2
+---
+
+# Worktree Commands
+
+Manage git worktrees with a fixed naming convention. Worktrees let you have multiple branches checked out in separate directories simultaneously — no need to stash and switch.
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `graft wt <branch>` | Create worktree for existing branch |
+| `graft wt <branch> -c` | Create new branch + worktree |
+| `graft wt remove <branch> [-f]` | Remove a worktree |
+| `graft wt list` | List all worktrees |
+
+---
+
+## Path Convention
+
+Worktree paths follow a fixed convention:
+
+```
+../<repoName>.wt.<safeBranch>/
+```
+
+Slashes in branch names are replaced with hyphens. For example:
+
+| Repo | Branch | Worktree Path |
+|------|--------|--------------|
+| `Graft` | `feature/api` | `../Graft.wt.feature-api/` |
+| `Graft` | `bugfix/auth` | `../Graft.wt.bugfix-auth/` |
+| `my-app` | `main` | `../my-app.wt.main/` |
+
+Worktrees are always created as siblings of the main repo directory.
+
+---
+
+## `graft wt <branch> [-c/--create]`
+
+Create a worktree for an existing branch. With `-c`, creates the branch first.
+
+```bash
+# Worktree for an existing branch
+$ graft wt feature/auth
+Created worktree at ../Graft.wt.feature-auth/
+
+# Create new branch + worktree
+$ graft wt feature/new-thing -c
+Created branch 'feature/new-thing'.
+Created worktree at ../Graft.wt.feature-new-thing/
+```
+
+New worktrees are automatically added to the [repo cache](scan) so they appear in `graft cd` and `graft status`.
+
+---
+
+## `graft wt remove <branch> [-f/--force]` (alias: `rm`)
+
+Remove the worktree for the named branch. Prompts for confirmation. Fails if uncommitted changes exist unless `-f` is used to override dirty checks. Also removes the worktree from the repo cache.
+
+```bash
+$ graft wt remove feature/auth
+Removed worktree at ../Graft.wt.feature-auth/
+
+# Force-remove even with uncommitted changes
+$ graft wt remove feature/auth -f
+```
+
+---
+
+## `graft wt list` (alias: `ls`)
+
+List all worktrees of this repository.
+
+```bash
+$ graft wt list
+/Users/dev/Graft                          main
+/Users/dev/Graft.wt.feature-auth          feature/auth
+/Users/dev/Graft.wt.feature-api           feature/api
+```
+
+---
+
+## Tips
+
+- **Jump to worktrees**: Use `graft cd <branch>` to navigate to a worktree by branch name. See [Navigation](navigation).
+- **Worktrees + stacks**: Worktrees are independent of stacks. You can create a worktree for any branch, whether or not it's part of a stack.
+- **Bulk remove**: `graft nuke wt` removes all worktrees at once. See [Nuke Commands](nuke).
+
+---
+
+## See Also
+
+- [Navigation](navigation) — Jump to worktrees with `graft cd`
+- [Scan & Discovery](scan) — Worktrees are auto-registered in the repo cache
+- [Nuke Commands](nuke) — Bulk remove all worktrees

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,6 +41,8 @@ Pushing auth/api... done.
 
 You can also sync a single branch: `graft stack sync auth/session`.
 
+See [Stack Commands](cli/stack#graft-stack-sync-branch) for the full reference.
+
 </details>
 
 ---
@@ -121,6 +123,8 @@ Graft saves its state to `.git/graft/operation.toml`. After resolving:
 
 If another conflict occurs further up the stack, the process repeats.
 
+See [Conflict Resolution](cli/conflict) for the full workflow guide.
+
 </details>
 
 ---
@@ -185,6 +189,8 @@ gt wt remove feature/auth -f      # force-remove
 ```
 
 Worktrees are useful when working on multiple stack branches at the same time without switching.
+
+See [Worktree Commands](cli/worktree) for the full reference.
 
 </details>
 
@@ -283,6 +289,8 @@ Check manually: `graft update`.
 
 No telemetry or usage data is collected. The only network request is a GitHub API call to check for new releases.
 
+See [Setup Commands](cli/setup#auto-update) for more details.
+
 </details>
 
 ---
@@ -299,5 +307,81 @@ The PR workflow is the same everywhere:
 4. `drop` + `sync` after each merge
 
 You create and manage PRs through your hosting platform's UI or CLI — Graft handles the branch management side.
+
+</details>
+
+---
+
+<details markdown="1">
+<summary><strong>How does repo scanning work?</strong></summary>
+
+Graft can discover git repositories across your machine. Register directories with `graft scan add`:
+
+```bash
+graft scan add ~/dev/projects
+graft scan add ~/dev/work
+```
+
+On every `graft` invocation, a background thread scans registered paths for git repos. The scan is non-blocking — your command runs immediately. Results are cached in `~/.config/graft/repo-cache.toml`.
+
+Discovered repos power two features:
+- **`graft cd <name>`** — jump to any repo or worktree by name. See [Navigation](cli/navigation).
+- **`graft status`** — cross-repo overview of all discovered repos. See [Status](cli/status).
+
+Worktrees created with `graft wt` are automatically added to the cache. Stale entries (deleted repos) are pruned automatically.
+
+See [Scan & Discovery](cli/scan) for the full command reference.
+
+</details>
+
+---
+
+<details markdown="1">
+<summary><strong>What is auto-fetch?</strong></summary>
+
+Auto-fetch runs `git fetch --all --quiet` in the background on every `graft` invocation, keeping your repos up to date without manual fetching.
+
+```bash
+# Enable for the current repo
+graft scan auto-fetch enable
+
+# Enable for a named repo
+graft scan auto-fetch enable my-app
+
+# See auto-fetch status for all repos
+graft scan auto-fetch list
+```
+
+Auto-fetch is rate-limited to once every 15 minutes per repo. Fetch failures are silently skipped — one repo failing doesn't block others.
+
+See [Scan & Discovery](cli/scan#auto-fetch-commands) for full details.
+
+</details>
+
+---
+
+<details markdown="1">
+<summary><strong>What does <code>graft status</code> show?</strong></summary>
+
+`graft status` gives a compact overview of all discovered repos:
+
+```bash
+$ graft status
+Graft  ~/dev/projects/Graft
+  branch   main
+  status   ✓ clean
+  stack    auth-refactor (3 branches)
+  worktrees  2 active
+
+my-app  ~/dev/projects/my-app
+  branch   feature/api
+  status   ↑2 ↓1  3 changed
+```
+
+Each repo shows: current branch, clean/dirty status, ahead/behind remote, active stack info, and worktree count.
+
+Use `graft status <reponame>` for detailed output including the full stack graph and worktree list.
+
+See [Status](cli/status) for full details.
 
 </details>

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,22 @@ Each branch is its own PR. Each PR shows only its own changes. `graft stack sync
 
 ---
 
+## Why Graft?
+
+When feature B depends on feature A (still in review), most teams hit the same wall:
+
+| Approach | Problem |
+|----------|---------|
+| Wait for A to merge | Blocks your work |
+| Branch B from A | PR shows both A and B's changes |
+| Merge main into A, then branch | Painful conflicts after squash merge |
+
+Graft fixes this. Each branch targets the one below it, so each PR shows only its own diff. `sync` propagates changes through the stack automatically.
+
+**Merge, not rebase.** Graft uses merge commits to keep branches in sync. Since your team squash-merges PRs anyway, those merge commits disappear from `main`. No force push, no rewritten history, safe for teams.
+
+---
+
 ## Install
 
 ### macOS / Linux
@@ -78,52 +94,45 @@ Update `feature/api-layer`'s PR to target `main`. Done.
 
 ---
 
-## Why Graft?
-
-When feature B depends on feature A (still in review), most teams hit the same wall:
-
-| Approach | Problem |
-|----------|---------|
-| Wait for A to merge | Blocks your work |
-| Branch B from A | PR shows both A and B's changes |
-| Merge main into A, then branch | Painful conflicts after squash merge |
-
-Graft fixes this. Each branch targets the one below it, so each PR shows only its own diff. `sync` propagates changes through the stack automatically.
-
-**Merge, not rebase.** Graft uses merge commits to keep branches in sync. Since your team squash-merges PRs anyway, those merge commits disappear from `main`. No force push, no rewritten history, safe for teams.
-
----
-
-## What Can Graft Do?
+## Feature Overview
 
 ### Stack Management
 
 | Command | Description |
 |---------|-------------|
-| `gt stack init <name>` | Create a new stack on the current branch |
-| `gt stack push -c <branch>` | Create a branch and add it to the top of the stack |
-| `gt stack log` | Display a visual graph of the stack |
-| `gt stack sync` | Merge the entire stack bottom-to-top, then push |
-| `gt stack commit -m <msg> [-b <branch>]` | Commit staged changes to any branch in the stack |
-| `gt stack remove <name>` | Remove a stack definition (git branches are kept) |
+| [`gt stack init`](cli/stack#graft-stack-init-name--b--base-branch) | Create a new stack on the current branch |
+| [`gt stack push -c`](cli/stack#graft-stack-push-branch--c--create) | Create a branch and add it to the top of the stack |
+| [`gt stack log`](cli/stack#graft-stack-log) | Display a visual graph of the stack |
+| [`gt stack sync`](cli/stack#graft-stack-sync-branch) | Merge the entire stack bottom-to-top, then push |
+| [`gt stack commit`](cli/stack#graft-stack-commit---message-message--b-branch---amend-alias-ci) | Commit staged changes to any branch in the stack |
+| [`gt stack remove`](cli/stack#graft-stack-remove-name--f--force-alias-rm) | Remove a stack definition (git branches are kept) |
 
 ### Worktree Management
 
 | Command | Description |
 |---------|-------------|
-| `gt wt <branch>` | Create a worktree for an existing branch |
-| `gt wt <branch> -c` | Create a new branch + worktree |
-| `gt wt remove <branch>` | Remove a worktree |
-| `gt wt list` | List all worktrees |
+| [`gt wt <branch>`](cli/worktree#graft-wt-branch--c--create) | Create a worktree for an existing branch |
+| [`gt wt <branch> -c`](cli/worktree#graft-wt-branch--c--create) | Create a new branch + worktree |
+| [`gt wt remove`](cli/worktree#graft-wt-remove-branch--f--force-alias-rm) | Remove a worktree |
+| [`gt wt list`](cli/worktree#graft-wt-list-alias-ls) | List all worktrees |
+
+### Repo Discovery & Navigation
+
+| Command | Description |
+|---------|-------------|
+| [`gt scan add`](cli/scan#graft-scan-add-directory) | Register a directory for repo scanning |
+| [`gt scan auto-fetch`](cli/scan#auto-fetch-commands) | Enable/disable background git fetch per repo |
+| [`gt cd <name>`](cli/navigation#graft-cd-name) | Jump to any repo or worktree by name |
+| [`gt status`](cli/status#graft-status-alias-st) | Cross-repo overview of all discovered repos |
 
 ### Setup
 
 | Command | Description |
 |---------|-------------|
-| `gt install` | Create `gt` symlink and `git gt` alias |
-| `gt update` | Check for and apply updates |
-| `gt version` | Print current version |
-| `gt ui` | Open the browser-based [web UI](web-ui) |
+| [`gt install`](cli/setup#graft-install) | Create `gt` symlink and `git gt` alias |
+| [`gt update`](cli/setup#graft-update) | Check for and apply updates |
+| [`gt version`](cli/setup#graft-version) | Print current version |
+| [`gt ui`](cli/setup#graft-ui) | Open the browser-based [web UI](web-ui) |
 
 ---
 
@@ -139,10 +148,18 @@ No .NET runtime required — Graft compiles to a native AOT binary.
 
 ---
 
-## Links
+## Learn More
 
 - [Workflow Guide](workflow) — Full stacked branches walkthrough
 - [CLI Reference](cli-reference) — Complete command reference
+  - [Stack Commands](cli/stack) — Create, manage, and sync stacked branches
+  - [Worktree Commands](cli/worktree) — Parallel checkouts with fixed naming
+  - [Scan & Discovery](cli/scan) — Repo scanning and auto-fetch
+  - [Navigation](cli/navigation) — Jump to repos and worktrees
+  - [Status](cli/status) — Cross-repo status overview
+  - [Nuke Commands](cli/nuke) — Bulk cleanup operations
+  - [Conflict Resolution](cli/conflict) — Handle merge conflicts during sync
+  - [Setup Commands](cli/setup) — Install, update, and aliases
 - [Web UI](web-ui) — Browser-based interface
 - [FAQ](faq) — Common questions
 - [Changelog](changelog) — What changed in each version

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -94,6 +94,8 @@ The UI communicates via a local REST API. These endpoints are available for scri
 
 ### Stack
 
+These endpoints correspond to the [Stack CLI commands](cli/stack).
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/stacks` | List all stacks |
@@ -110,12 +112,16 @@ The UI communicates via a local REST API. These endpoints are available for scri
 
 ### Conflict Resolution
 
+These endpoints correspond to the [Conflict Resolution CLI commands](cli/conflict).
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | POST | `/api/sync/continue` | Continue after resolving a conflict |
 | POST | `/api/sync/abort` | Abort the in-progress sync |
 
 ### Worktree
+
+These endpoints correspond to the [Worktree CLI commands](cli/worktree).
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
@@ -124,6 +130,8 @@ The UI communicates via a local REST API. These endpoints are available for scri
 | DELETE | `/api/worktrees` | Delete a worktree |
 
 ### Nuke
+
+These endpoints correspond to the [Nuke CLI commands](cli/nuke).
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -289,3 +289,13 @@ The tradeoff is merge commits in your branch history. But since most teams **squ
 - **Safe for teams** — shared branches are never force-pushed
 - **Built for squash-merge** — merge commits in branches don't matter
 - **Conflict handling** — clear error messages, `--continue` / `--abort` workflow
+
+---
+
+## Next Steps
+
+- [Stack Commands](cli/stack) — Full reference for all stack operations
+- [Conflict Resolution](cli/conflict) — Detailed conflict handling guide
+- [Worktree Commands](cli/worktree) — Work on multiple branches simultaneously
+- [Scan & Discovery](cli/scan) — Register repos and enable auto-fetch
+- [FAQ](faq) — Common questions about stacked branches


### PR DESCRIPTION
## Summary

- Split monolithic `cli-reference.md` (433 lines) into 8 focused child pages under `docs/cli/`: Stack, Worktree, Scan & Discovery, Navigation, Status, Nuke, Conflict Resolution, Setup
- Reorder home page to lead with "Why Graft?" before install instructions
- Add heading anchors and back-to-top via `_config.yml`
- Enrich FAQ with 3 new entries (repo scanner, auto-fetch, graft status) and cross-links to CLI sub-pages
- Add auto-fetch commands to scan docs (previously missing from CLI reference)
- Cross-link Web UI API tables to corresponding CLI command pages
- Mark JetBrains plugin as "Planned" in changelog

Closes #26

## Test plan

- [ ] `cd docs && bundle exec jekyll serve` builds without errors
- [ ] Sidebar shows correct parent/child hierarchy (CLI Reference → 8 children)
- [ ] Right-side TOC appears on longer pages (stack.md, conflict.md)
- [ ] Heading anchor links work (hover over heading → click link icon)
- [ ] All cross-links between pages resolve correctly
- [ ] index.md shows "Why Graft?" before Install section