### PR TITLE
Fix docs accuracy, CI test coverage, and merge --continue bug

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -52,14 +52,17 @@ jobs:
           dotnet build tests/Graft.Core.Tests/Graft.Core.Tests.csproj --no-incremental
           dotnet build tests/Graft.Cli.Tests/Graft.Cli.Tests.csproj --no-incremental
 
-      - name: Test with coverage
-        continue-on-error: true
+      - name: Test Graft.Core
         run: |
           dotnet test tests/Graft.Core.Tests/Graft.Core.Tests.csproj \
             --no-build \
             --logger trx \
             --collect:"XPlat Code Coverage" \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+
+      - name: Test Graft.Cli
+        if: always()
+        run: |
           dotnet test tests/Graft.Cli.Tests/Graft.Cli.Tests.csproj \
             --no-build \
             --logger trx \

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ A cross-platform CLI tool for managing stacked branches and git worktrees.
 
 Git's stacked branches and worktree features are powerful but ergonomically painful. Graft fixes that:
 
-- **Stacked branches** — Track dependencies, cascade rebases automatically, commit to any branch in a stack
-- **Worktree management** — Opinionated layouts, template files (.env, configs), Windows drive letter mapping
+- **Stacked branches** — Track dependencies, merge parent branches bottom-to-top, commit to any branch in a stack
+- **Worktree management** — Create and manage git worktrees with a fixed naming convention
 - **Web UI** — Browser-based visual interface for stacks and worktrees (`graft ui`)
-- **Hosting integration** — Create and manage PRs for entire stacks (GitHub, GitLab)
+- **Repo discovery & navigation** — Scan directories for repos, navigate by name or branch with `graft cd`
+- **Cross-repo status** — See branch, ahead/behind, changed files, stacks, and worktrees across all repos
 
 ## Documentation
 
@@ -26,8 +27,7 @@ Pre-built binaries for all platforms (Windows, macOS, Linux — x64 and arm64) a
 
 ## Status
 
-Early development. Not yet usable.
-
+In active development. See [Releases](https://github.com/radaiko/Graft/releases) for pre-built binaries.
 
 ## License
 

--- a/docs/spec/data-storage.md
+++ b/docs/spec/data-storage.md
@@ -13,7 +13,6 @@ All repo-specific data lives under the `.git/graft/` directory (resolved via `gi
 ├── config.toml           # Repo-level settings
 ├── stacks/
 │   └── <name>.toml       # One file per stack
-├── worktrees.toml        # Worktree layout and templates
 └── operation.toml        # Transient: tracks in-progress operations
 ```
 
@@ -22,7 +21,6 @@ All repo-specific data lives under the `.git/graft/` directory (resolved via `gi
 ```toml
 [defaults]
 trunk = "main"                # Default trunk branch for new stacks
-stack_pr_strategy = "chain"   # PR creation strategy: "chain" or "independent"
 ```
 
 All fields are optional. Defaults are applied when a field is missing.
@@ -30,7 +28,6 @@ All fields are optional. Defaults are applied when a field is missing.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `defaults.trunk` | string | `"main"` | Default trunk branch for `graft stack init` |
-| `defaults.stack_pr_strategy` | string | `"chain"` | How PRs are created for stacked branches |
 
 ### `stacks/<name>.toml` — Stack Definition
 
@@ -73,37 +70,6 @@ pr_state = "open"
 | `pr_state` | string | no | `"open"`, `"merged"`, or `"closed"` (default: `"open"`) |
 
 **Branch ordering:** Branches are ordered bottom-to-top. Index 0 is merged from the trunk. Each subsequent branch is merged from the one before it.
-
-### `worktrees.toml` — Worktree Configuration
-
-```toml
-[layout]
-pattern = "../{name}"
-
-[templates]
-[[templates.files]]
-src = ".env.template"
-dst = ".env"
-mode = "copy"
-
-[[templates.files]]
-src = ".vscode/settings.json"
-dst = ".vscode/settings.json"
-mode = "symlink"
-```
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `layout.pattern` | string | `"../{name}"` | Path pattern for new worktrees. Must contain `{name}`. Resolved relative to the repo root. |
-| `templates.files` | array of tables | `[]` | Files to copy or symlink into new worktrees |
-
-**Template file fields:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `src` | string | yes | Source path relative to the repo root |
-| `dst` | string | yes | Destination path relative to the worktree root |
-| `mode` | string | no | `"copy"` (default) or `"symlink"` |
 
 ### `operation.toml` — In-Progress Operation State
 

--- a/docs/spec/installation-and-updates.md
+++ b/docs/spec/installation-and-updates.md
@@ -93,12 +93,6 @@ See [Error Handling — Update Rollback](./error-handling.md#update-rollback) fo
 
 Before applying an update, the staged binary path is validated to be within the expected `~/.config/graft/staging/` directory. Paths that resolve outside this directory are rejected to prevent path traversal attacks from tampered state files.
 
-### Disabling Auto-Update
-
-```
-graft config set update.enabled false
-```
-
 ### State File
 
 Update state is stored in `~/.config/graft/update-state.toml`. See [Data Storage — `update-state.toml`](./data-storage.md) for the full schema.

--- a/docs/spec/ui.md
+++ b/docs/spec/ui.md
@@ -118,15 +118,6 @@ These endpoints wrap the worktree commands described in the [Product Specificati
 | GET | `/api/status` | Cross-repo status overview (all discovered repos) |
 | GET | `/api/status/{reponame}` | Detailed status for a specific repo |
 
-### Config Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/config` | Read repo config (`.git/graft/config.toml`) |
-| PUT | `/api/config` | Write updated config |
-| GET | `/api/config/worktree` | Read worktree config (`worktrees.toml`) |
-| PUT | `/api/config/worktree` | Write updated worktree config |
-
 ### Git Context Endpoints
 
 | Method | Path | Description |
@@ -157,13 +148,7 @@ A table of active worktrees showing: path, branch, HEAD SHA. Each row has a Remo
 
 ### 3. Settings View
 
-A form that reads from and writes to the TOML config files:
-
-- **Defaults** — trunk branch name, PR strategy
-- **Worktree Layout** — pattern string (must contain `{name}`)
-- **Templates** — list of template file mappings (src, dst, mode). Add/remove rows.
-
-Each section has a Save button. Validation is inline.
+*Planned.* This view will provide a form for editing repo-level configuration (e.g., default trunk branch). Not yet implemented.
 
 ---
 

--- a/src/Graft.Core/Git/GitRunner.cs
+++ b/src/Graft.Core/Git/GitRunner.cs
@@ -39,6 +39,9 @@ public sealed class GitRunner
         foreach (var arg in args)
             process.StartInfo.ArgumentList.Add(arg);
 
+        // Prevent git from ever opening an editor (e.g. during merge --continue).
+        process.StartInfo.Environment["GIT_EDITOR"] = "true";
+
         process.Start();
 
         // Read both streams concurrently to prevent pipe buffer deadlock.


### PR DESCRIPTION
## Summary

- **Docs:** Remove references to unimplemented features (worktree templates, hosting integration, `stack_pr_strategy`, `graft config` command, config API endpoints). Update README status and feature descriptions to match what's actually built.
- **Bug fix:** Set `GIT_EDITOR=true` in `GitRunner` to prevent `git merge --continue` from trying to open an editor in non-interactive environments — fixes the `Continue_AfterConflictResolution_ResumesOperation` test failure.
- **CI:** Split the SonarCloud test step into separate steps per project with `if: always()` so `Graft.Cli.Tests` runs even when `Graft.Core.Tests` fails. Remove `continue-on-error: true` so test failures properly fail the job.

## Files changed

| File | Change |
|------|--------|
| `README.md` | Rewrite feature bullets, update status |
| `docs/spec/data-storage.md` | Remove `worktrees.toml` section and `stack_pr_strategy` |
| `docs/spec/installation-and-updates.md` | Remove `graft config set` reference |
| `docs/spec/ui.md` | Remove config endpoints and unimplemented Settings View features |
| `src/Graft.Core/Git/GitRunner.cs` | Set `GIT_EDITOR=true` in process environment |
| `.github/workflows/sonarcloud.yml` | Split test step, remove `continue-on-error` |

## Test plan

- [x] All 236 Core tests pass (including previously failing `Continue_AfterConflictResolution_ResumesOperation`)
- [x] All 90 Cli tests pass
- [x] Grep confirms no dangling references to removed terms in docs
- [ ] SonarCloud CI runs both test projects and reports correctly