### PR TITLE
Fix four open issues: VS extension crash, TUI jumping, scan improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ graft wt list (ls)                                     # List worktrees
 graft scan add <directory>                             # Register directory for repo scanning
 graft scan remove (rm) <directory>                     # Unregister directory
 graft scan list (ls)                                   # List registered scan paths
+graft scan update                                      # Fetch all cached repos once (manual)
 graft scan auto-fetch enable [<name>]                  # Enable auto-fetch for a repo
 graft scan auto-fetch disable [<name>]                 # Disable auto-fetch for a repo
 graft scan auto-fetch list                             # List repos with auto-fetch status

--- a/docs/changelog/cli.md
+++ b/docs/changelog/cli.md
@@ -8,6 +8,15 @@ All Graft CLI releases. Download binaries from the [GitHub Releases](https://git
 
 ---
 
+## [Unreleased]
+
+### Added
+- **CLI:** `graft scan update` — fetch all cached repos once, regardless of auto-fetch settings (#35)
+- **CLI:** `graft scan add` now triggers an immediate scan so repos are discoverable right away (#36)
+
+### Fixed
+- **TUI:** Fix interactive picker jumping higher on each keystroke due to incorrect cursor-up at start of render (#37)
+
 ## [0.3.0]
 
 ### Added

--- a/docs/changelog/vs.md
+++ b/docs/changelog/vs.md
@@ -6,6 +6,11 @@ title: Visual Studio
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Extension:** Fix Stack Explorer tool window crash on startup by making constructor public for VS reflection-based instantiation (#38)
+
 ## [0.1.1]
 
 ### Changed

--- a/docs/cli/scan.md
+++ b/docs/cli/scan.md
@@ -15,6 +15,7 @@ Manage directories that Graft scans for git repositories. Discovered repos power
 | `graft scan add <directory>` | Register a directory for scanning |
 | `graft scan remove <directory>` | Unregister a directory |
 | `graft scan list` | List registered scan paths |
+| `graft scan update` | Fetch all repos once (manual one-time fetch) |
 | `graft scan auto-fetch enable [<name>]` | Enable background fetch for a repo |
 | `graft scan auto-fetch disable [<name>]` | Disable background fetch for a repo |
 | `graft scan auto-fetch list` | List repos with auto-fetch status |
@@ -30,9 +31,11 @@ Register a directory to scan for git repositories.
 ```bash
 $ graft scan add ~/dev/projects
 Added scan path: /Users/dev/projects
+Scanning for repositories...
+Scan complete.
 ```
 
-On every `graft` invocation, a background thread scans all registered paths for git repositories. The scan is non-blocking — the main command runs immediately. Results are cached in `~/.config/graft/repo-cache.toml`.
+Adding a scan path immediately triggers a synchronous scan so repos are discoverable right away. On subsequent `graft` invocations, a background thread scans all registered paths automatically. Results are cached in `~/.config/graft/repo-cache.toml`.
 
 ### `graft scan remove <directory>` (alias: `rm`)
 
@@ -52,6 +55,25 @@ $ graft scan list
 /Users/dev/projects
 /Users/dev/work
 ```
+
+---
+
+## Update Command
+
+### `graft scan update`
+
+Fetch all cached repos once, regardless of auto-fetch settings or rate limits. Reports per-repo status.
+
+```bash
+$ graft scan update
+Fetching all repos...
+  ok       Graft
+  ok       my-app
+  failed   offline-repo
+Done.
+```
+
+This is a one-time manual fetch. For automatic background fetching, see [Auto-Fetch Commands](#auto-fetch-commands) below.
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -141,7 +141,7 @@ Graft maintains a list of directories to scan for git repositories. On every inv
 
 ### `graft scan add <directory>`
 
-Register a directory to scan for git repositories. The path is stored in the global config (`~/.config/graft/config.toml`). Fails if the directory does not exist.
+Register a directory to scan for git repositories. The path is stored in the global config (`~/.config/graft/config.toml`). Fails if the directory does not exist. Immediately triggers a synchronous scan so repos are discoverable right away.
 
 ### `graft scan remove <directory>` (alias: `rm`)
 
@@ -157,6 +157,10 @@ On every `graft` invocation, a background thread scans all registered paths for 
 
 - **Stale removal**: If a previously cached repo no longer exists on disk, it is automatically removed from the cache.
 - **Worktree integration**: `graft wt` automatically adds new worktrees to the repo cache. `graft wt remove` automatically removes them.
+
+### `graft scan update`
+
+Fetch all cached repos once, regardless of auto-fetch settings or rate limits. Reports per-repo success/failure. Useful as a one-time manual refresh for all repos.
 
 ### Auto-Fetch
 

--- a/src/Graft.Core/Tui/FuzzyPicker.cs
+++ b/src/Graft.Core/Tui/FuzzyPicker.cs
@@ -133,9 +133,8 @@ public static class FuzzyPicker
     /// </summary>
     private static int Render<T>(string prompt, string query, List<PickerItem<T>> filtered, int selectedIndex, int scrollOffset, int totalCount, int previousLines)
     {
-        // Move cursor back to prompt line from wherever it ended up last render
-        if (previousLines > 0)
-            Err.Write($"\x1b[{previousLines}A");
+        // Cursor is already at the prompt line (moved back at end of previous render).
+        // Just return to column 1.
         Err.Write("\r");
 
         // Prompt line (line 0)

--- a/src/Graft.VS2026Extension/ToolWindows/StackExplorerToolWindow.cs
+++ b/src/Graft.VS2026Extension/ToolWindows/StackExplorerToolWindow.cs
@@ -13,7 +13,7 @@ namespace Graft.VS2026Extension.ToolWindows
             Caption = "Stack Explorer";
         }
 
-        internal StackExplorerToolWindow(GraftService? service) : base(null)
+        public StackExplorerToolWindow(GraftService? service) : base(null)
         {
             Caption = "Stack Explorer";
             Content = new StackExplorerControl(service);

--- a/tests/Graft.Cli.Tests/Commands/ScanCommandTests.cs
+++ b/tests/Graft.Cli.Tests/Commands/ScanCommandTests.cs
@@ -52,6 +52,13 @@ public sealed class ScanCommandTests
     }
 
     [Fact]
+    public void ScanUpdate_ParsesWithoutErrors()
+    {
+        var result = CliTestHelper.Parse("scan update");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void Scan_HasExpectedSubcommands()
     {
         var root = CliTestHelper.BuildRootCommand();
@@ -69,6 +76,8 @@ public sealed class ScanCommandTests
         Assert.Contains("rm", subcommands);
         Assert.Contains("list", subcommands);
         Assert.Contains("ls", subcommands);
+        Assert.Contains("update", subcommands);
+        Assert.Contains("auto-fetch", subcommands);
     }
 
 }


### PR DESCRIPTION
- Fix #38: Make StackExplorerToolWindow constructor public so VS can
  instantiate it via reflection in the async tool window factory pattern
- Fix #37: Remove incorrect cursor-up at start of FuzzyPicker.Render()
  that caused the TUI to jump higher on each keystroke
- Fix #36: Run RepoScanner.ScanAndUpdateCache() immediately after
  graft scan add so repos are discoverable right away
- Fix #35: Add 'graft scan update' command that fetches all cached repos
  once (like auto-fetch but manual, for all repos regardless of flag)

https://claude.ai/code/session_01RS33VKKgZPCMRGWSJykFhR