### PR TITLE
Fix scan integration tests polluting global config

### DIFF
--- a/tests/Graft.Cli.Tests/Commands/InProcessScanTests.cs
+++ b/tests/Graft.Cli.Tests/Commands/InProcessScanTests.cs
@@ -20,6 +20,9 @@ public sealed class InProcessScanTests : IDisposable
 
     public void Dispose()
     {
+        // Remove the scan path from config first (before deleting the directory)
+        InProcessCliRunner.RunAsync(null, "scan", "remove", _tempDir).GetAwaiter().GetResult();
+
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, recursive: true);
     }


### PR DESCRIPTION
## Summary
- **Fixes #40** — scan integration tests were adding temp directories to the real `~/.config/graft/config.toml` without cleaning them up
- `InProcessScanTests.Dispose()` now calls `scan remove` before deleting the temp directory from disk

## Test plan
- [x] All 401 tests pass (111 CLI + 290 Core)
- [x] Verified `config.toml` stays clean after running the full test suite