### PR TITLE
Fix graft cd not changing shell directory

### DIFF
--- a/docs/cli/navigation.md
+++ b/docs/cli/navigation.md
@@ -27,12 +27,11 @@ If multiple repos or worktrees match the name, all matches are shown and you pic
 
 ### How It Works
 
-A child process can't change the parent shell's working directory. Graft handles this with a shell function that wraps the binary:
+A child process can't change the parent shell's working directory. Graft solves this with a shell function wrapper (the same pattern used by zoxide, direnv, etc.).
 
-1. `graft cd <name>` prints the target directory path to stdout
-2. The shell function captures this and runs `cd` in the parent shell
+`graft install` automatically detects your shell and writes wrapper functions into your profile (`~/.zshrc`, `~/.bashrc`, `config.fish`, or `$PROFILE`). Restart your shell and `graft cd` just works. `graft uninstall` removes the integration.
 
-The shell function is set up automatically by `graft install`. If you're using `graft` directly (without the shell function), the path is printed but the directory change won't happen — use `cd $(graft cd <name>)` as a workaround.
+The wrapper functions intercept `graft cd` and `gt cd`, capture the path from stdout, and run `cd` in the parent shell. All other subcommands pass through to the binary unchanged.
 
 ---
 

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -22,12 +22,13 @@ Installation, aliases, updates, and the web UI.
 
 ## `graft install`
 
-Create the `gt` shortcut next to the `graft` binary and add `git gt` alias to your global git config.
+Create the `gt` shortcut, add `git gt` alias, and set up shell integration for `graft cd`.
 
 ```bash
 $ graft install
-Created symlink: gt → /usr/local/bin/graft
-Added git alias: git gt → graft
+Installed aliases: gt, git gt
+Added shell integration to /Users/you/.zshrc
+Restart your shell or run: source /Users/you/.zshrc
 ```
 
 After installation, you can use any of these interchangeably:
@@ -42,11 +43,26 @@ On macOS/Linux, `gt` is a symlink. On Windows, it's a copy of the binary.
 
 The `git gt` alias is written to `~/.gitconfig` as `gt = !graft`.
 
+### Shell Integration
+
+`graft install` detects your current shell and writes wrapper functions into your profile:
+
+| Shell | Profile |
+|-------|---------|
+| Zsh | `~/.zshrc` |
+| Bash | `~/.bashrc` (or `~/.bash_profile`) |
+| Fish | `~/.config/fish/config.fish` |
+| PowerShell | `$PROFILE` |
+
+The wrapper functions intercept `graft cd` and `gt cd`, capture the target path from stdout, and run `cd` in the parent shell. All other subcommands pass through to the binary unchanged. This is the same pattern used by zoxide, direnv, and similar tools.
+
+If your shell can't be detected, `graft install` will print a notice. Supported shells: bash, zsh, fish, PowerShell.
+
 ---
 
 ## `graft uninstall`
 
-Remove the `gt` shortcut and `git gt` alias.
+Remove the `gt` shortcut, `git gt` alias, and shell integration from your profile.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ curl -fsSL https://raw.githubusercontent.com/radaiko/Graft/main/install.sh | bas
 irm https://raw.githubusercontent.com/radaiko/Graft/main/install.ps1 | iex
 ```
 
-The installer places `graft` in `~/.local/bin` and sets up two shortcuts: `gt` (symlink) and `git gt` (git alias). All three forms are interchangeable.
+The installer places `graft` in `~/.local/bin` and runs `graft install`, which sets up shortcuts (`gt`, `git gt`) and shell integration for [`graft cd`](./cli/navigation.md).
 
 Graft is a single native binary — no runtime, no dependencies.
 

--- a/docs/spec/installation-and-updates.md
+++ b/docs/spec/installation-and-updates.md
@@ -52,7 +52,7 @@ All three forms are identical: `graft stack sync`, `gt stack sync`, `git gt stac
 
 **Block format:** The injected code is wrapped in markers for clean removal:
 
-```
+```text
 # >>> graft shell integration >>>
 graft() { ... }
 gt() { ... }

--- a/docs/spec/installation-and-updates.md
+++ b/docs/spec/installation-and-updates.md
@@ -34,6 +34,34 @@ All three forms are identical: `graft stack sync`, `gt stack sync`, `git gt stac
 **Uninstall:**
 1. Deletes the `gt` symlink/copy.
 2. Removes the `alias.gt` entry from `~/.gitconfig` using `git config --global --unset alias.gt`. Exit code 5 (key not found) is ignored.
+3. Removes the shell integration block from the user's shell profile.
+
+---
+
+## Shell Integration
+
+`graft install` also writes shell wrapper functions into the user's shell profile to enable `graft cd` (a subprocess can't change the parent shell's working directory).
+
+**Detection:** The current shell is detected from the `SHELL` environment variable (Unix) or `PSModulePath` (Windows/PowerShell).
+
+**Profile files:**
+- **Zsh:** `~/.zshrc`
+- **Bash:** `~/.bashrc` (preferred if it exists, otherwise `~/.bash_profile`)
+- **Fish:** `~/.config/fish/config.fish`
+- **PowerShell:** `~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1` (Windows) or `~/.config/powershell/Microsoft.PowerShell_profile.ps1` (Unix)
+
+**Block format:** The injected code is wrapped in markers for clean removal:
+
+```
+# >>> graft shell integration >>>
+graft() { ... }
+gt() { ... }
+# <<< graft shell integration <<<
+```
+
+**Idempotent:** If the marker block already exists, install is a no-op.
+
+**Uninstall:** Removes everything between (and including) the markers.
 
 ---
 

--- a/src/Graft.Cli/Commands/SetupCommands.cs
+++ b/src/Graft.Cli/Commands/SetupCommands.cs
@@ -34,7 +34,10 @@ public static class InstallCommand
                 else
                 {
                     Console.WriteLine($"Added shell integration to {shellResult.ProfilePath}");
-                    Console.WriteLine("Restart your shell or run: source " + shellResult.ProfilePath);
+                    var reloadCmd = shellResult.Shell is "pwsh" or "powershell"
+                        ? $". {shellResult.ProfilePath}"
+                        : $"source {shellResult.ProfilePath}";
+                    Console.WriteLine($"Restart your shell or run: {reloadCmd}");
                 }
             }
             catch (Exception ex)
@@ -62,8 +65,10 @@ public static class UninstallCommand
                     ?? throw new InvalidOperationException(
                         "Cannot determine binary path. Run graft using its full path.");
                 AliasInstaller.Uninstall(binaryPath);
-                ShellProfileInstaller.Uninstall();
-                Console.WriteLine("Removed aliases and shell integration.");
+                var shellRemoved = ShellProfileInstaller.Uninstall();
+                Console.WriteLine(shellRemoved
+                    ? "Removed aliases and shell integration."
+                    : "Removed aliases.");
             }
             catch (Exception ex)
             {

--- a/src/Graft.Cli/Commands/SetupCommands.cs
+++ b/src/Graft.Cli/Commands/SetupCommands.cs
@@ -19,6 +19,23 @@ public static class InstallCommand
                         "Cannot determine binary path. Run graft using its full path.");
                 AliasInstaller.Install(binaryPath);
                 Console.WriteLine("Installed aliases: gt, git gt");
+
+                var shellResult = ShellProfileInstaller.Install();
+                if (shellResult is null)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine("Could not detect your shell. Shell integration for 'graft cd' was not installed.");
+                    Console.WriteLine("Supported shells: bash, zsh, fish, PowerShell.");
+                }
+                else if (shellResult.AlreadyPresent)
+                {
+                    Console.WriteLine($"Shell integration already in {shellResult.ProfilePath}");
+                }
+                else
+                {
+                    Console.WriteLine($"Added shell integration to {shellResult.ProfilePath}");
+                    Console.WriteLine("Restart your shell or run: source " + shellResult.ProfilePath);
+                }
             }
             catch (Exception ex)
             {
@@ -45,7 +62,8 @@ public static class UninstallCommand
                     ?? throw new InvalidOperationException(
                         "Cannot determine binary path. Run graft using its full path.");
                 AliasInstaller.Uninstall(binaryPath);
-                Console.WriteLine("Removed aliases: gt, git gt");
+                ShellProfileInstaller.Uninstall();
+                Console.WriteLine("Removed aliases and shell integration.");
             }
             catch (Exception ex)
             {

--- a/src/Graft.Core/Install/ShellInitGenerator.cs
+++ b/src/Graft.Core/Install/ShellInitGenerator.cs
@@ -1,0 +1,112 @@
+namespace Graft.Core.Install;
+
+public static class ShellInitGenerator
+{
+    public static string GenerateBash() => GeneratePosix();
+
+    public static string GenerateZsh() => GeneratePosix();
+
+    public static string GenerateFish() =>
+        """
+        function graft
+            if test (count $argv) -ge 1; and test "$argv[1]" = "cd"
+                set -l rest $argv[2..-1]
+                set -l dir (command graft cd $rest)
+                set -l rc $status
+                if test $rc -eq 0; and test -n "$dir"
+                    builtin cd "$dir"; or return
+                end
+                return $rc
+            end
+            command graft $argv
+        end
+
+        function gt
+            if test (count $argv) -ge 1; and test "$argv[1]" = "cd"
+                set -l rest $argv[2..-1]
+                set -l dir (command gt cd $rest)
+                set -l rc $status
+                if test $rc -eq 0; and test -n "$dir"
+                    builtin cd "$dir"; or return
+                end
+                return $rc
+            end
+            command gt $argv
+        end
+        """;
+
+    public static string GeneratePowershell() =>
+        """
+        function Invoke-Graft {
+            if ($args.Count -ge 1 -and $args[0] -eq 'cd') {
+                $rest = $args[1..($args.Count - 1)]
+                $dir = & (Get-Command graft -CommandType Application | Select-Object -First 1) cd @rest
+                $rc = $LASTEXITCODE
+                if ($rc -eq 0 -and $dir) {
+                    Set-Location $dir
+                }
+                return
+            }
+            & (Get-Command graft -CommandType Application | Select-Object -First 1) @args
+        }
+
+        function Invoke-Gt {
+            if ($args.Count -ge 1 -and $args[0] -eq 'cd') {
+                $rest = $args[1..($args.Count - 1)]
+                $dir = & (Get-Command gt -CommandType Application | Select-Object -First 1) cd @rest
+                $rc = $LASTEXITCODE
+                if ($rc -eq 0 -and $dir) {
+                    Set-Location $dir
+                }
+                return
+            }
+            & (Get-Command gt -CommandType Application | Select-Object -First 1) @args
+        }
+
+        Set-Alias -Name graft -Value Invoke-Graft -Scope Global -Force
+        Set-Alias -Name gt -Value Invoke-Gt -Scope Global -Force
+        """;
+
+    public static string? Generate(string shell) =>
+        shell.ToLowerInvariant() switch
+        {
+            "bash" => GenerateBash(),
+            "zsh" => GenerateZsh(),
+            "fish" => GenerateFish(),
+            "powershell" or "pwsh" => GeneratePowershell(),
+            _ => null,
+        };
+
+    public static IReadOnlyList<string> SupportedShells => ["bash", "zsh", "fish", "powershell", "pwsh"];
+
+    private static string GeneratePosix() =>
+        """
+        graft() {
+          if [ "$1" = "cd" ]; then
+            shift
+            local dir
+            dir="$(command graft cd "$@")"
+            local rc=$?
+            if [ $rc -eq 0 ] && [ -n "$dir" ]; then
+              builtin cd "$dir" || return
+            fi
+            return $rc
+          fi
+          command graft "$@"
+        }
+
+        gt() {
+          if [ "$1" = "cd" ]; then
+            shift
+            local dir
+            dir="$(command gt cd "$@")"
+            local rc=$?
+            if [ $rc -eq 0 ] && [ -n "$dir" ]; then
+              builtin cd "$dir" || return
+            fi
+            return $rc
+          fi
+          command gt "$@"
+        }
+        """;
+}

--- a/src/Graft.Core/Install/ShellInitGenerator.cs
+++ b/src/Graft.Core/Install/ShellInitGenerator.cs
@@ -39,12 +39,13 @@ public static class ShellInitGenerator
         """
         function Invoke-Graft {
             if ($args.Count -ge 1 -and $args[0] -eq 'cd') {
-                $rest = $args[1..($args.Count - 1)]
+                $rest = if ($args.Count -gt 1) { $args[1..($args.Count - 1)] } else { @() }
                 $dir = & (Get-Command graft -CommandType Application | Select-Object -First 1) cd @rest
                 $rc = $LASTEXITCODE
                 if ($rc -eq 0 -and $dir) {
                     Set-Location $dir
                 }
+                $global:LASTEXITCODE = $rc
                 return
             }
             & (Get-Command graft -CommandType Application | Select-Object -First 1) @args
@@ -52,12 +53,13 @@ public static class ShellInitGenerator
 
         function Invoke-Gt {
             if ($args.Count -ge 1 -and $args[0] -eq 'cd') {
-                $rest = $args[1..($args.Count - 1)]
+                $rest = if ($args.Count -gt 1) { $args[1..($args.Count - 1)] } else { @() }
                 $dir = & (Get-Command gt -CommandType Application | Select-Object -First 1) cd @rest
                 $rc = $LASTEXITCODE
                 if ($rc -eq 0 -and $dir) {
                     Set-Location $dir
                 }
+                $global:LASTEXITCODE = $rc
                 return
             }
             & (Get-Command gt -CommandType Application | Select-Object -First 1) @args

--- a/src/Graft.Core/Install/ShellProfileInstaller.cs
+++ b/src/Graft.Core/Install/ShellProfileInstaller.cs
@@ -1,0 +1,142 @@
+using System.Runtime.InteropServices;
+
+namespace Graft.Core.Install;
+
+public record ShellIntegrationResult(string Shell, string ProfilePath, bool AlreadyPresent);
+
+public static class ShellProfileInstaller
+{
+    private const string BeginMarker = "# >>> graft shell integration >>>";
+    private const string EndMarker = "# <<< graft shell integration <<<";
+
+    public static ShellIntegrationResult? Install(string? profilePathOverride = null)
+    {
+        var (shell, profilePath) = profilePathOverride != null
+            ? (DetectShell() ?? "unknown", profilePathOverride)
+            : DetectShellAndProfile();
+
+        if (profilePath is null)
+            return null;
+
+        var code = ShellInitGenerator.Generate(shell);
+        if (code is null)
+            return null;
+
+        var block = $"{BeginMarker}\n{code}\n{EndMarker}\n";
+
+        // Ensure parent directory exists (e.g. ~/.config/fish/)
+        var dir = Path.GetDirectoryName(profilePath);
+        if (dir != null && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        if (File.Exists(profilePath))
+        {
+            var content = File.ReadAllText(profilePath);
+            if (content.Contains(BeginMarker))
+                return new ShellIntegrationResult(shell, profilePath, AlreadyPresent: true);
+
+            // Append with a blank line separator
+            var separator = content.Length > 0 && !content.EndsWith('\n') ? "\n\n" : "\n";
+            File.AppendAllText(profilePath, separator + block);
+        }
+        else
+        {
+            File.WriteAllText(profilePath, block);
+        }
+
+        return new ShellIntegrationResult(shell, profilePath, AlreadyPresent: false);
+    }
+
+    public static bool Uninstall(string? profilePathOverride = null)
+    {
+        var (shell, profilePath) = profilePathOverride != null
+            ? (DetectShell() ?? "unknown", profilePathOverride)
+            : DetectShellAndProfile();
+
+        if (profilePath is null || !File.Exists(profilePath))
+            return false;
+
+        var content = File.ReadAllText(profilePath);
+
+        var startIdx = content.IndexOf(BeginMarker, StringComparison.Ordinal);
+        if (startIdx < 0)
+            return false;
+
+        var endIdx = content.IndexOf(EndMarker, startIdx, StringComparison.Ordinal);
+        if (endIdx < 0)
+            return false;
+
+        endIdx += EndMarker.Length;
+        // Also consume the trailing newline if present
+        if (endIdx < content.Length && content[endIdx] == '\n')
+            endIdx++;
+
+        // Remove leading blank line if the block was preceded by one
+        if (startIdx > 0 && content[startIdx - 1] == '\n')
+            startIdx--;
+
+        var newContent = content[..startIdx] + content[endIdx..];
+        File.WriteAllText(profilePath, newContent);
+        return true;
+    }
+
+    private static (string shell, string? profilePath) DetectShellAndProfile()
+    {
+        var shell = DetectShell();
+        if (shell is null)
+            return ("unknown", null);
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var profilePath = shell switch
+        {
+            "zsh" => Path.Combine(home, ".zshrc"),
+            "bash" => GetBashProfile(home),
+            "fish" => Path.Combine(home, ".config", "fish", "config.fish"),
+            "pwsh" or "powershell" => GetPowershellProfile(),
+            _ => null,
+        };
+
+        return (shell, profilePath);
+    }
+
+    private static string? DetectShell()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+            if (psModulePath != null)
+                return "pwsh";
+            return null;
+        }
+
+        var shellEnv = Environment.GetEnvironmentVariable("SHELL");
+        if (shellEnv is null)
+            return null;
+
+        var name = Path.GetFileName(shellEnv);
+        return name switch
+        {
+            "zsh" => "zsh",
+            "bash" => "bash",
+            "fish" => "fish",
+            _ => null,
+        };
+    }
+
+    private static string GetBashProfile(string home)
+    {
+        // Prefer .bashrc if it exists; fall back to .bash_profile (macOS login shells)
+        var bashrc = Path.Combine(home, ".bashrc");
+        if (File.Exists(bashrc))
+            return bashrc;
+        return Path.Combine(home, ".bash_profile");
+    }
+
+    private static string? GetPowershellProfile()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Path.Combine(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1");
+        return Path.Combine(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+    }
+}

--- a/src/Graft.Core/Install/ShellProfileInstaller.cs
+++ b/src/Graft.Core/Install/ShellProfileInstaller.cs
@@ -67,12 +67,16 @@ public static class ShellProfileInstaller
             return false;
 
         endIdx += EndMarker.Length;
-        // Also consume the trailing newline if present
-        if (endIdx < content.Length && content[endIdx] == '\n')
+        // Also consume the trailing newline (CRLF or LF)
+        if (endIdx < content.Length && content[endIdx] == '\r' && endIdx + 1 < content.Length && content[endIdx + 1] == '\n')
+            endIdx += 2;
+        else if (endIdx < content.Length && content[endIdx] == '\n')
             endIdx++;
 
-        // Remove leading blank line if the block was preceded by one
-        if (startIdx > 0 && content[startIdx - 1] == '\n')
+        // Remove leading blank line if the block was preceded by one (CRLF or LF)
+        if (startIdx >= 2 && content[startIdx - 2] == '\r' && content[startIdx - 1] == '\n')
+            startIdx -= 2;
+        else if (startIdx > 0 && content[startIdx - 1] == '\n')
             startIdx--;
 
         var newContent = content[..startIdx] + content[endIdx..];


### PR DESCRIPTION
## Summary

- `graft cd` printed the correct path but never changed the shell's working directory (a subprocess can't change its parent's cwd)
- `graft install` now auto-detects the user's shell and writes wrapper functions directly into their profile (`~/.zshrc`, `~/.bashrc`, `config.fish`, or `$PROFILE`)
- The wrappers intercept `graft cd` / `gt cd`, capture the path, and run `cd` in the parent shell — all other subcommands pass through unchanged
- `graft uninstall` cleanly removes the injected block
- Install is idempotent — running it again is a no-op

## New files

- `src/Graft.Core/Install/ShellInitGenerator.cs` — generates shell wrapper functions for bash, zsh, fish, PowerShell
- `src/Graft.Core/Install/ShellProfileInstaller.cs` — detects shell, injects/removes the wrapper block in the profile file

## Test plan

- [x] `dotnet build` succeeds
- [x] All 401 tests pass
- [x] `graft install` detects zsh, writes functions to `~/.zshrc`
- [x] Re-running `graft install` reports "already present" (idempotent)
- [x] `graft uninstall` removes the block cleanly
- [ ] Manual: source `~/.zshrc`, run `gt cd <name>`, verify directory changes