### PR TITLE
Slim down graft status with ANSI colors

### DIFF
--- a/src/Graft.Cli/Ansi.cs
+++ b/src/Graft.Cli/Ansi.cs
@@ -1,0 +1,38 @@
+namespace Graft.Cli;
+
+/// <summary>
+/// ANSI escape code helpers for colorized terminal output.
+/// Respects NO_COLOR env var and non-TTY output.
+/// </summary>
+internal static class Ansi
+{
+    private static readonly bool _enabled = CheckEnabled();
+
+    public static bool Enabled => _enabled;
+
+    public static string Reset => _enabled ? "\x1b[0m" : "";
+    public static string Bold => _enabled ? "\x1b[1m" : "";
+    public static string Dim => _enabled ? "\x1b[2m" : "";
+
+    public static string Red => _enabled ? "\x1b[31m" : "";
+    public static string Green => _enabled ? "\x1b[32m" : "";
+    public static string Yellow => _enabled ? "\x1b[33m" : "";
+    public static string Blue => _enabled ? "\x1b[34m" : "";
+    public static string Magenta => _enabled ? "\x1b[35m" : "";
+    public static string Cyan => _enabled ? "\x1b[36m" : "";
+    public static string Gray => _enabled ? "\x1b[90m" : "";
+
+    private static bool CheckEnabled()
+    {
+        if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
+            return false;
+        try
+        {
+            return !Console.IsOutputRedirected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Redesigns `graft status` overview from 5 lines per repo (with blank line separators) to **1 line per repo** with colored badges
- Adds ANSI color throughout both overview and detailed views: bold names, cyan branches, green/red sync indicators, yellow changes, magenta stacks, blue worktrees
- Adds `Ansi` helper class that respects `NO_COLOR` env var and piped/redirected output

## Before
```
Graft  ~/dev/private/Graft
  branch   main
  status   ↑1  3 changed  1 untracked
  stack    auth(3 branches)
  worktrees  2 active

OtherRepo  ~/dev/work/Other
  branch   develop
  status   clean
  stack    —
  worktrees  —
```

## After
```
  Graft      main  ↑1  3Δ 1?  ⚑auth(3)  2wt
  OtherRepo  develop  ✓
```

## Test plan
- [x] `dotnet build` succeeds
- [x] All 401 tests pass (`dotnet test`)
- [x] `graft status` shows compact 1-line-per-repo output with colors
- [x] `graft status <name>` shows colorized detailed view
- [x] `NO_COLOR=1 graft status` disables all ANSI codes
- [x] Piped output (`graft status | cat`) disables colors